### PR TITLE
Add preflight in `site.yml` to ensure no Wireguard IP duplicates

### DIFF
--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -1,3 +1,22 @@
+- name: Ensure no duplicate WireGuard IPs
+  hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: Gather Wireguard IPs
+      set_fact:
+        wireguard_ips: "{{ wireguard_ips | default([]) + [hostvars[item].wireguard_ip] }}"
+      loop: "{{ groups['all'] }}"
+      when: hostvars[item].wireguard_ip is defined
+
+    - name: Check if there are duplicates in IP list
+      set_fact:
+        wireguard_ip_duplicates: "{{ wireguard_ips | unique | length != wireguard_ips | length }}"
+
+    - name: Fail if there are duplicates
+      fail:
+        msg: "Duplicate Wireguard IP address found"
+      when: wireguard_ip_duplicates
+
 - name: Setup Kubernetes Node
   hosts: all
   become: yes

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -1,4 +1,4 @@
-- name: Ensure no duplicate WireGuard IPs
+- name: Ensure no duplicate Wireguard IPs
   hosts: localhost
   gather_facts: no
   tasks:


### PR DESCRIPTION
The added play ensures no two Wireguard IPs are the same in the inventory.

**With a duplicate Wireguard IP, it fails and stops the playbook:**

![image](https://github.com/user-attachments/assets/63065676-3b44-4703-8355-48c58b7418e9)

<details>
  <summary>inventory.yml used for the test</summary>
  
  As you can see, `chutes-miner-cpu-0` and `chutes-miner-gpu-2` have the same `wireguard_ip` -> `192.168.0.1`
```
all:
  vars:
    # This is your SSH public key, e.g. cat ~/.ssh/id_rsa.pub
    ssh_keys:
      - "ssh-rsa AAAA... user@hostnane"
      - "ssh-rsa BBBB... user@hostnane"
    # The username you want to use to login to those machines (and your public key will be added to).
    user: billybob
    # The initial username to login with, for fresh nodes that may not have your username setup.
    ansible_user: ubuntu
    # The default validator each GPU worker node will be assigned to.
    validator: 5Dt7HZ7Zpw4DppPxFM7Ke3Cm7sDAWhsZXmM5ZAmE7dSVJbcQ
    # By default, no nodes are the primary (CPU node running all the apps, wireguard, etc.) Override this flag exactly once below.
    is_primary: false
    # We assume GPU is enabled on all nodes, but of course you need to disable this for the CPU nodes below.
    gpu_enabled: true
    # The port you'll be using for the registry proxy, MUST MATCH chart/values.yaml registry.service.nodePort!
    registry_port: 30500
    # SSH sometimes just hangs without this...
    ansible_ssh_common_args: '-o ControlPath=none'
    # SSH retries...
    ansible_ssh_retries: 3
    # Ubuntu major/minor version.
    ubuntu_major: "22"
    ubuntu_minor: "04"
    # CUDA version - leave as-is unless using h200s, in which case either use 12-5 or skip_cuda: true (if provider already pre-installed drivers)
    cuda_version: "12-6"
    # NVIDA GPU drivers - leave as-is unless using h200s, in which case it would be 555
    nvidia_version: "560"
    # Flag to skip the cuda install entirely, if the provider already has cuda 12.x+ installed (note some chutes will not work unless 12.6+)
    skip_cuda: false

  hosts:
    # This would be the main node, which runs postgres, redis, gepetto, etc.
    chutes-miner-cpu-0:
      ansible_host: 1.0.0.0
      external_ip: 1.0.0.0
      wireguard_ip: 192.168.0.1
      gpu_enabled: false
      is_primary: true

    # These are the GPU nodes, which actually run the chutes.
    chutes-miner-gpu-0:
      ansible_host: 1.0.0.1
      external_ip: 1.0.0.1
      wireguard_ip: 192.168.0.3
    chutes-miner-gpu-1:
      ansible_host: 1.0.0.2
      external_ip: 1.0.0.2
      wireguard_ip: 192.168.0.4
    chutes-miner-gpu-2:
      ansible_host: 1.0.0.3
      external_ip: 1.0.0.3
      wireguard_ip: 192.168.0.1

```
</details>

**Without any duplicates in the inventory it executes normally:**

![image](https://github.com/user-attachments/assets/1728f94c-04d3-466e-8221-af6a7e61c18b)

<details>
  <summary>inventory.yml used for the test</summary>

```
all:
  vars:
    # This is your SSH public key, e.g. cat ~/.ssh/id_rsa.pub
    ssh_keys:
      - "ssh-rsa AAAA... user@hostnane"
      - "ssh-rsa BBBB... user@hostnane"
    # The username you want to use to login to those machines (and your public key will be added to).
    user: billybob
    # The initial username to login with, for fresh nodes that may not have your username setup.
    ansible_user: ubuntu
    # The default validator each GPU worker node will be assigned to.
    validator: 5Dt7HZ7Zpw4DppPxFM7Ke3Cm7sDAWhsZXmM5ZAmE7dSVJbcQ
    # By default, no nodes are the primary (CPU node running all the apps, wireguard, etc.) Override this flag exactly once below.
    is_primary: false
    # We assume GPU is enabled on all nodes, but of course you need to disable this for the CPU nodes below.
    gpu_enabled: true
    # The port you'll be using for the registry proxy, MUST MATCH chart/values.yaml registry.service.nodePort!
    registry_port: 30500
    # SSH sometimes just hangs without this...
    ansible_ssh_common_args: '-o ControlPath=none'
    # SSH retries...
    ansible_ssh_retries: 3
    # Ubuntu major/minor version.
    ubuntu_major: "22"
    ubuntu_minor: "04"
    # CUDA version - leave as-is unless using h200s, in which case either use 12-5 or skip_cuda: true (if provider already pre-installed drivers)
    cuda_version: "12-6"
    # NVIDA GPU drivers - leave as-is unless using h200s, in which case it would be 555
    nvidia_version: "560"
    # Flag to skip the cuda install entirely, if the provider already has cuda 12.x+ installed (note some chutes will not work unless 12.6+)
    skip_cuda: false

  hosts:
    # This would be the main node, which runs postgres, redis, gepetto, etc.
    chutes-miner-cpu-0:
      ansible_host: 1.0.0.0
      external_ip: 1.0.0.0
      wireguard_ip: 192.168.0.1
      gpu_enabled: false
      is_primary: true

    # These are the GPU nodes, which actually run the chutes.
    chutes-miner-gpu-0:
      ansible_host: 1.0.0.1
      external_ip: 1.0.0.1
      wireguard_ip: 192.168.0.3
    chutes-miner-gpu-1:
      ansible_host: 1.0.0.2
      external_ip: 1.0.0.2
      wireguard_ip: 192.168.0.4
    chutes-miner-gpu-2:
      ansible_host: 1.0.0.3
      external_ip: 1.0.0.3
      wireguard_ip: 192.168.0.5

```
</details>

