### PR TITLE
ci: set read-only workflow token permissions

### DIFF
--- a/.github/workflows/chart-version-check.yml
+++ b/.github/workflows/chart-version-check.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'charts/**'
 
+
+permissions:
+  contents: read
 jobs:
   chart-version-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-version-check.yml
+++ b/.github/workflows/docker-version-check.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - 'docker/**'
 
+
+permissions:
+  contents: read
 jobs:
   docker-version-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/package-version-check.yml
+++ b/.github/workflows/package-version-check.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - 'src/**'
 
+
+permissions:
+  contents: read
 jobs:
   package-version-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ruff-check.yml
+++ b/.github/workflows/ruff-check.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - 'src/**'
 
+
+permissions:
+  contents: read
 jobs:
   ruff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- set explicit read-only `GITHUB_TOKEN` permissions for CI workflows that only need repository checkout/read access
- leave release/deploy/write-capable workflows unchanged

## Why
This follows GitHub Actions least-privilege guidance and reduces the default token scope available to routine CI jobs without changing the test/build commands.

## Verification
- Parsed the changed workflow YAML with PyYAML.
- Ran `git diff --check`.
